### PR TITLE
Stand-alone view for Issues

### DIFF
--- a/src/static/app.js
+++ b/src/static/app.js
@@ -315,7 +315,7 @@
 					}
 
 					// See what State this is...
-					if ($state.is('app.project.issues.project-issues.view-issue') || $state.is('app.project.issues.project-issues')){
+					if ($stateParams.hasOwnProperty('milestoneId') && ($state.is('app.project.issues.project-issues.view-issue') || $state.is('app.project.issues.project-issues.edit-issue'))) {
 						// Single Issue view/edit
 						return dataFactory.milestone($stateParams.projectId, $stateParams.milestoneId).then(function(response) {
 							var obj = {};

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -303,7 +303,7 @@
 			url: '?f&l',
 			templateUrl: '/project-issues/issues.html',
 			resolve: {
-				issues: ['$stateParams', 'app.dataFactory', function($stateParams, dataFactory) {
+				issues: ['$stateParams', '$state', 'app.dataFactory', function($stateParams, $state, dataFactory) {
 
 					var filters = {};
 					if (angular.isDefined($stateParams.f)) {
@@ -314,7 +314,19 @@
 						filters.open = true;
 					}
 
-					return dataFactory.milestones($stateParams.projectId, filters);
+					// See what State this is...
+					if ($state.is('app.project.issues.project-issues.view-issue') || $state.is('app.project.issues.project-issues')){
+						// Single Issue view/edit
+						return dataFactory.milestone($stateParams.projectId, $stateParams.milestoneId).then(function(response) {
+							var obj = {};
+							obj[response.id] = response;
+							return obj;
+						});
+					} else {
+						// Issue list
+						return dataFactory.milestones($stateParams.projectId, filters);
+					}
+
 				}]
 			}, controller: 'app.projectIssuesCtrl'
 		});

--- a/src/static/components/filters.js
+++ b/src/static/components/filters.js
@@ -343,8 +343,6 @@
 				for (var i = _keys.length - 1; i >= 0; i--) {
 					if (issues[_keys[i]].open == open) {
 						_filter.push(issues[_keys[i]]);
-					} else if (issues[_keys[i]]._view) {
-						_filter.push(issues[_keys[i]]);
 					}
 				}
 			}

--- a/src/static/project-issues/issue-directives.js
+++ b/src/static/project-issues/issue-directives.js
@@ -42,7 +42,8 @@
 		return {
 			restrict: 'A',
 			scope: {
-				issue: '=issueView'
+				issue: '=issueView',
+				watch: '@watch'
 			}, controller: ['$scope', '$stateParams', 'app.dataFactory', function($scope, $stateParams, dataFactory) {
 				$scope.init = function() {
 					$scope.comments = {};
@@ -76,6 +77,12 @@
 
 					$scope.showLabelsPopover = false;
 				};
+
+				$scope.$watch(function() {
+					return $scope.watch ? $scope.issue : null;
+				}, function(newIssue, oldIssie) {
+					$scope.init();
+				});
 
 				$scope.commentsPluralizeWhen = {
 					'0': 'No comments',
@@ -145,7 +152,8 @@
 		return {
 			restrict: 'A',
 			scope: {
-				issue: '=issueEdit'
+				issue: '=issueEdit',
+				watch: '@watch'
 			}, controller: ['$scope', '$state', '$stateParams', 'app.dataFactory', function($scope, $state, $stateParams, dataFactory) {
 				$scope.init = function() {
 					$scope.comments = {};
@@ -182,6 +190,12 @@
 					$scope.issue._name = angular.copy($scope.issue.name);
 					$scope.issue._description = angular.copy($scope.issue.description);
 				};
+
+				$scope.$watch(function() {
+					return $scope.watch ? $scope.issue : null;
+				}, function(newIssue, oldIssie) {
+					$scope.init();
+				});
 
 				$scope.commentsPluralizeWhen = {
 					'0': 'No comments',

--- a/src/static/project-issues/issues.html
+++ b/src/static/project-issues/issues.html
@@ -1,49 +1,62 @@
-<div class="row" style="margin-bottom:30px;">
-	<div class="col-sm-8">
-		<div class="input-group">
-			<input type="text" class="form-control" ng-model="searchOptions.text.name" placeholder="Search issues...">
-
-			<div class="input-group-btn">
-				<div class="btn-group">
-					<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
-						{{ searchOptions.open | capitalize }} issues <span class="caret"></span>
-					</button>
-					<ul class="dropdown-menu" role="menu">
-						<li ui-sref-active="active"><a ui-sref="app.project.issues.project-issues({ f: '' })">Open</a></li>
-						<li ui-sref-active="active"><a ui-sref="app.project.issues.project-issues({ f: 'closed' })">Closed</a></li>
-						<li class="divider"></li>
-						<li ui-sref-active="active"><a ui-sref="app.project.issues.project-issues({ f: 'all' })">All</a></li>
-					</ul>
-				</div>
+<div ng-if="singleIssueView">
+	<div class="projects-list-group" >
+		<div class="list-group popout">
+			<div class="list-group-item view">
+				<div ng-if="singleIssueView._view && !singleIssueView._edit" issue-view="singleIssueView" watch="true"></div>
+				<div ng-if="singleIssueView._view && singleIssueView._edit" issue-edit="singleIssueView"></div>
 			</div>
 		</div>
-
-		<p>
-			<ul class="list-inline">
-				<li><a href="#" ng-click="searchOptions.showLabelsPopover = !searchOptions.showLabelsPopover"><strong>Labels</strong></a>:
-				<div select-labels-popover="searchOptions.labels" issue="issue" ng-show="searchOptions.showLabelsPopover"></div></li>
-				<li ng-repeat="label in searchOptions.labels | filterDisplayObjects" style="padding:0px;"><span label="label"></span></li>
-			</ul>
-		</p>
-
-	</div>
-	<div class="col-sm-4 text-right">
-		<a ui-sref="app.project.issues.create-issue" class="btn btn-primary">New issue</a>
 	</div>
 </div>
 
-<div class="projects-list-group">
-	<p>Showing <span ng-pluralize count="(issueResults).length" when="issuesPluralizeWhen">{{ searchOptions.open }}</span> of N total</p>
-	<div class="list-group popout">
-		<div class="list-group-item" ng-class="{ 'view': (issue._view) }" ng-click="issueClick(issue);" ng-repeat="issue in issues | filterDisplayObjects | issueOpen:searchOptions.open | issueLabels:searchOptions.labels | filter:searchOptions.text | orderBy:'_created':true as issueResults">
-			<div ng-if="!issue._view" issue-list-item="issue"></div>
-			<div ng-if="issue._view && !issue._edit" issue-view="issue"></div>
-			<div ng-if="issue._view && issue._edit" issue-edit="issue"></div>
+<div ng-show="!singleIssueView">
+	<div class="row" style="margin-bottom:30px;">
+		<div class="col-sm-8" ng-show="!singleIssueView">
+			<div class="input-group">
+				<input type="text" class="form-control" ng-model="searchOptions.text.name" placeholder="Search issues...">
+				<div class="input-group-btn">
+					<div class="btn-group">
+						<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+							{{ searchOptions.open | capitalize }} issues <span class="caret"></span>
+						</button>
+						<ul class="dropdown-menu" role="menu">
+							<li ui-sref-active="active"><a ui-sref="app.project.issues.project-issues({ f: '' })">Open</a></li>
+							<li ui-sref-active="active"><a ui-sref="app.project.issues.project-issues({ f: 'closed' })">Closed</a></li>
+							<li class="divider"></li>
+							<li ui-sref-active="active"><a ui-sref="app.project.issues.project-issues({ f: 'all' })">All</a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+			<p>
+				<ul class="list-inline">
+					<li><a href="#" ng-click="searchOptions.showLabelsPopover = !searchOptions.showLabelsPopover"><strong>Labels</strong></a>:
+					<div select-labels-popover="searchOptions.labels" issue="issue" ng-show="searchOptions.showLabelsPopover"></div></li>
+					<li ng-repeat="label in searchOptions.labels | filterDisplayObjects" style="padding:0px;"><span label="label"></span></li>
+				</ul>
+			</p>
+		</div>
+		<div class="col-sm-8" ng-show="singleIssueView">
+			<p><a ui-sref="app.project.issues.project-issues">Back to all Issues</a></p>
+		</div>
+		<div class="col-sm-4 text-right">
+			<a ui-sref="app.project.issues.create-issue" class="btn btn-primary">New issue</a>
 		</div>
 	</div>
-	<p ng-show="issueResults.length == 0">Try broading your search or <a ui-sref="app.project.issues.create-issue">open a new issue</a>.</p>
-</div>
 
-<div class="text-center" ng-show="issues._cursor">
-	<a href="#" ng-click="loadMore();">Load more</a>
+	<div class="projects-list-group">
+		<p>Showing <span ng-pluralize count="(issueResults).length" when="issuesPluralizeWhen">{{ searchOptions.open }}</span> of N total</p>
+		<div class="list-group popout">
+			<div class="list-group-item" ng-class="{ 'view': (issue._view) }" ng-click="issueClick(issue);" ng-repeat="issue in issues | filterDisplayObjects | issueOpen:searchOptions.open | issueLabels:searchOptions.labels | filter:searchOptions.text | orderBy:'_created':true as issueResults">
+				<div ng-if="!issue._view" issue-list-item="issue"></div>
+				<div ng-if="issue._view && !issue._edit" issue-view="issue"></div>
+				<div ng-if="issue._view && issue._edit" issue-edit="issue"></div>
+			</div>
+		</div>
+		<p ng-show="issueResults.length == 0">Try broading your search or <a ui-sref="app.project.issues.create-issue">open a new issue</a>.</p>
+	</div>
+
+	<div class="text-center" ng-show="issues._cursor">
+		<a href="#" ng-click="loadMore();">Load more</a>
+	</div>
 </div>

--- a/src/static/project-issues/issues.html
+++ b/src/static/project-issues/issues.html
@@ -3,7 +3,7 @@
 		<div class="list-group popout">
 			<div class="list-group-item view">
 				<div ng-if="singleIssueView._view && !singleIssueView._edit" issue-view="singleIssueView" watch="true"></div>
-				<div ng-if="singleIssueView._view && singleIssueView._edit" issue-edit="singleIssueView"></div>
+				<div ng-if="singleIssueView._view && singleIssueView._edit" issue-edit="singleIssueView" watch="true"></div>
 			</div>
 		</div>
 	</div>

--- a/src/static/project-issues/project-issues-ctrl.js
+++ b/src/static/project-issues/project-issues-ctrl.js
@@ -30,6 +30,8 @@
 					}
 				}
 			}
+
+			$scope.singleIssueView = false;
 		};
 
 		$scope.$on('backgroundClick', function() {
@@ -55,18 +57,42 @@
 			// Add the `_view` property of the currently viewed issue;
 			if (angular.isDefined(toParams.milestoneId)) {
 				// If we have this Milestone go ahead and view it...
-				if (angular.isDefined($scope.issues[toParams.milestoneId])) {
+				if (angular.isDefined($scope.issues[toParams.milestoneId]) && (fromState.name == 'app.project.issues.project-issues' || !$scope.singleIssueView)) {
+					console.log('type of: '+ typeof $scope.issueResults)
+					// var keys = Object.keys($scope.issueResults);
+					console.log($scope.issueResults.length);
+					var found = false;
+					for (var i = $scope.issueResults.length - 1; i >= 0; i--) {
+						if ($scope.issueResults[i].id == toParams.milestoneId) {
+							// Found
+							console.log('The issue is found in issueResults!!!!');
+							found = true;
+							continue;
+						} else {
+							// Not found
+							console.log('The issue is NOT found in issueResults!!!!');
+							continue;
+						}
+					};
 					$scope.viewOrEditMilestone(toParams.milestoneId, (toState.name == 'app.project.issues.project-issues.edit-issue'));
+					if (found) {
+						$scope.singleIssueView = false;
+					} else {
+						$scope.singleIssueView = $scope.issues[toParams.milestoneId];
+					}
 				} else {
 					// ... otherwise load it!
 					dataFactory.milestone($scope.projectId, toParams.milestoneId).then(function(response) {
 						if (!response.error) {
 							$scope.viewOrEditMilestone(toParams.milestoneId, (toState.name == 'app.project.issues.project-issues.edit-issue'));
+							$scope.singleIssueView = response;
 						} else {
 							alert('Error loading Issue.');
 						}
 					});
 				}
+			} else {
+				$scope.singleIssueView = false;
 			}
 
 			if (angular.isDefined(toParams.f)) {
@@ -134,9 +160,11 @@
 		}, true);
 
 		$scope.viewOrEditMilestone = function(milestoneId, edit) {
-			$scope.issues[milestoneId]._view = true;
-			if (edit) {
-				$scope.issues[milestoneId]._edit = true;
+			if (angular.isDefined($scope.issues[milestoneId])) {
+				$scope.issues[milestoneId]._view = true;
+				if (edit) {
+					$scope.issues[milestoneId]._edit = true;
+				}
 			}
 		};
 


### PR DESCRIPTION
Issues may now be viewed as "stand-alone" without the popout.

This happens when:
- The Issue list currently being viewed **does not contain the requested Issue ID**.
