### PR TITLE
Removed `number` from API Milestone objects

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -321,7 +321,6 @@ class Milestone(ndb.Model):
             'name': self.name,
             'description': self.description,
             'open': self.open,
-            'number': self.number,
             'user': self.user
         }
         if comments:

--- a/src/static/project-issues/issue-list-item.html
+++ b/src/static/project-issues/issue-list-item.html
@@ -13,5 +13,5 @@
 		<!-- <span class="glyphicon glyphicon-play-circle" ng-show="issue.open"></span> -->
 		<span class="glyphicon glyphicon-ok-circle"></span>
 	</span>
-	#{{ issue.number }} created on {{ issue._created | date:'mediumDate' }} by {{ issue.user }}
+	#{{ issue.id }} created on {{ issue._created | date:'mediumDate' }} by {{ issue.user }}
 </p>

--- a/src/static/project-issues/issue-view.html
+++ b/src/static/project-issues/issue-view.html
@@ -1,6 +1,6 @@
 <div class="row">
 	<div class="col-sm-10">
-		<h1>{{ issue.name }} <span class="text-muted">#{{ issue.number }}</span></h1>
+		<h1>{{ issue.name }} <span class="text-muted">#{{ issue.id }}</span></h1>
 	</div>
 	<div class="col-sm-2 text-right" style="padding-top:10px;">
 		<a ui-sref="app.project.issues.project-issues.edit-issue({ milestoneId: issue.id })" title="Edit issue." class="text-muted" style="position:relative; top:1px; margin-right:10px;">Edit</a>


### PR DESCRIPTION
The front-end now uses the `id` instead of `number`.
